### PR TITLE
Dup default message before replacing variables so we don't mutate the default message

### DIFF
--- a/lib/eye/notify/hipchat.rb
+++ b/lib/eye/notify/hipchat.rb
@@ -35,10 +35,11 @@ module Eye
       private
 
       def parse_message
+        filled_message = message.dup
         %w{time host message name full_name pid level}.each do |variable|
-          message.gsub!("##{variable}#", send("msg_#{variable}").to_s) if message =~ /##{variable}#/
+          filled_message.gsub!("##{variable}#", send("msg_#{variable}").to_s) if filled_message =~ /##{variable}#/
         end
-        message
+        filled_message
       end
 
       def msg_time


### PR DESCRIPTION
I was noticing that every time eye notified hipchat of a process restarting because the memory limit was exceeded, the message showed the same samples of memory usage and had the same timestamp.

[8:12 AM] Eye Bot: sidekiq on hostname Bounded memory(<500Mb): [*500Mb, *502Mb, *503Mb] send to [:restart] at 16 Jan 05:49.
[8:18 AM] Eye Bot: sidekiq on hostname Bounded memory(<500Mb): [*500Mb, *502Mb, *503Mb] send to [:restart] at 16 Jan 05:49.

Notice the timestamps at the beginning of the line that come from hipchat don't match the timestamps on the end of the line coming from eye-hipchat.

Looks like replacing the variables previously mutated the default message such that it no longer contained placeholders but rather their filled-in values from the first notification. Then subsequent notifications would send a message identical to the first notification since there were no longer any placeholders to replace.

Dup-ing the default message first allows us to replace the variables only for that notification without affecting the default message.

Thanks for eye-hipchat!